### PR TITLE
Make ThreadedSparseMatrixCSC subtype of AbstractSparseMatrixCSC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
           - 'nightly'
         os:
           - ubuntu-latest
+          - macOS-latest
+          - windows-latest
         arch:
           - x64
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+    tags: '*'
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.4' # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
+          - '1' # Leave this line unchanged. '1' will automatically expand to the latest stable 1.x release of Julia.
+          - 'nightly'
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v1
+        with:
+          file: lcov.info

--- a/src/ThreadedSparseArrays.jl
+++ b/src/ThreadedSparseArrays.jl
@@ -3,7 +3,7 @@ module ThreadedSparseArrays
 using LinearAlgebra
 import LinearAlgebra: mul!
 using SparseArrays
-import SparseArrays: getcolptr
+import SparseArrays: getcolptr, AbstractSparseMatrixCSC
 const AdjOrTransDenseMatrix = if VERSION < v"1.6.0-rc2"
     SparseArrays.AdjOrTransStridedOrTriangularMatrix
 else
@@ -36,15 +36,15 @@ Base.iterate(it::RangeIterator, i::Int=1) = i>it.k ? nothing : (endpos(it,i-1)+1
 Thin container around `A::SparseMatrixCSC` that will enable certain
 threaded multiplications of `A` with dense matrices.
 """
-struct ThreadedSparseMatrixCSC{Tv,Ti,At} <: AbstractSparseMatrix{Tv,Ti}
+struct ThreadedSparseMatrixCSC{Tv,Ti,At} <: AbstractSparseMatrixCSC{Tv,Ti}
     A::At
-    ThreadedSparseMatrixCSC(A::At) where {Tv,Ti,At<:AbstractSparseMatrix{Tv,Ti}} =
+    ThreadedSparseMatrixCSC(A::At) where {Tv,Ti,At<:AbstractSparseMatrixCSC{Tv,Ti}} =
         new{Tv,Ti,At}(A)
 end
 
 Base.size(A::ThreadedSparseMatrixCSC, args...) = size(A.A, args...)
-Base.eltype(A::ThreadedSparseMatrixCSC) = eltype(A.A)
-Base.getindex(A::ThreadedSparseMatrixCSC, args...) = getindex(A.A, args...)
+# Base.eltype(A::ThreadedSparseMatrixCSC) = eltype(A.A)
+# Base.getindex(A::ThreadedSparseMatrixCSC, args...) = getindex(A.A, args...)
 
 # Need to override printing
 # Need to forward findnz, etc
@@ -53,13 +53,13 @@ for f in [:rowvals, :nonzeros, :getcolptr]
     @eval SparseArrays.$(f)(A::ThreadedSparseMatrixCSC) = SparseArrays.$(f)(A.A)
 end
 
-# For non-threaded implementations, fallback to sparse methods and not generic matmul.
-mul!(C::AbstractVector, A::ThreadedSparseMatrixCSC, B::AbstractVector, α::Number, β::Number) = mul!(C, A.A, B, α, β)
-mul!(C::AbstractMatrix, A::ThreadedSparseMatrixCSC, B::AbstractMatrix, α::Number, β::Number) = mul!(C, A.A, B, α, β)
-mul!(C::AbstractVector, A::Adjoint{<:Any,<:ThreadedSparseMatrixCSC}, B::AbstractVector, α::Number, β::Number) = mul!(C, adjoint(A.parent.A), B, α, β)
-mul!(C::AbstractMatrix, A::Adjoint{<:Any,<:ThreadedSparseMatrixCSC}, B::AbstractMatrix, α::Number, β::Number) = mul!(C, adjoint(A.parent.A), B, α, β)
-mul!(C::AbstractVector, A::Transpose{<:Any,<:ThreadedSparseMatrixCSC}, B::AbstractVector, α::Number, β::Number) = mul!(C, transpose(A.parent.A), B, α, β)
-mul!(C::AbstractMatrix, A::Transpose{<:Any,<:ThreadedSparseMatrixCSC}, B::AbstractMatrix, α::Number, β::Number) = mul!(C, transpose(A.parent.A), B, α, β)
+# # For non-threaded implementations, fallback to sparse methods and not generic matmul.
+# mul!(C::AbstractVector, A::ThreadedSparseMatrixCSC, B::AbstractVector, α::Number, β::Number) = mul!(C, A.A, B, α, β)
+# mul!(C::AbstractMatrix, A::ThreadedSparseMatrixCSC, B::AbstractMatrix, α::Number, β::Number) = mul!(C, A.A, B, α, β)
+# mul!(C::AbstractVector, A::Adjoint{<:Any,<:ThreadedSparseMatrixCSC}, B::AbstractVector, α::Number, β::Number) = mul!(C, adjoint(A.parent.A), B, α, β)
+# mul!(C::AbstractMatrix, A::Adjoint{<:Any,<:ThreadedSparseMatrixCSC}, B::AbstractMatrix, α::Number, β::Number) = mul!(C, adjoint(A.parent.A), B, α, β)
+# mul!(C::AbstractVector, A::Transpose{<:Any,<:ThreadedSparseMatrixCSC}, B::AbstractVector, α::Number, β::Number) = mul!(C, transpose(A.parent.A), B, α, β)
+# mul!(C::AbstractMatrix, A::Transpose{<:Any,<:ThreadedSparseMatrixCSC}, B::AbstractMatrix, α::Number, β::Number) = mul!(C, transpose(A.parent.A), B, α, β)
 
 function mul!(C::StridedVecOrMat, A::ThreadedSparseMatrixCSC, B::Union{StridedVector,AdjOrTransDenseMatrix}, α::Number, β::Number)
     size(A, 2) == size(B, 1) || throw(DimensionMismatch())

--- a/src/ThreadedSparseArrays.jl
+++ b/src/ThreadedSparseArrays.jl
@@ -43,23 +43,10 @@ struct ThreadedSparseMatrixCSC{Tv,Ti,At} <: AbstractSparseMatrixCSC{Tv,Ti}
 end
 
 Base.size(A::ThreadedSparseMatrixCSC, args...) = size(A.A, args...)
-# Base.eltype(A::ThreadedSparseMatrixCSC) = eltype(A.A)
-# Base.getindex(A::ThreadedSparseMatrixCSC, args...) = getindex(A.A, args...)
-
-# Need to override printing
-# Need to forward findnz, etc
 
 for f in [:rowvals, :nonzeros, :getcolptr]
     @eval SparseArrays.$(f)(A::ThreadedSparseMatrixCSC) = SparseArrays.$(f)(A.A)
 end
-
-# # For non-threaded implementations, fallback to sparse methods and not generic matmul.
-# mul!(C::AbstractVector, A::ThreadedSparseMatrixCSC, B::AbstractVector, α::Number, β::Number) = mul!(C, A.A, B, α, β)
-# mul!(C::AbstractMatrix, A::ThreadedSparseMatrixCSC, B::AbstractMatrix, α::Number, β::Number) = mul!(C, A.A, B, α, β)
-# mul!(C::AbstractVector, A::Adjoint{<:Any,<:ThreadedSparseMatrixCSC}, B::AbstractVector, α::Number, β::Number) = mul!(C, adjoint(A.parent.A), B, α, β)
-# mul!(C::AbstractMatrix, A::Adjoint{<:Any,<:ThreadedSparseMatrixCSC}, B::AbstractMatrix, α::Number, β::Number) = mul!(C, adjoint(A.parent.A), B, α, β)
-# mul!(C::AbstractVector, A::Transpose{<:Any,<:ThreadedSparseMatrixCSC}, B::AbstractVector, α::Number, β::Number) = mul!(C, transpose(A.parent.A), B, α, β)
-# mul!(C::AbstractMatrix, A::Transpose{<:Any,<:ThreadedSparseMatrixCSC}, B::AbstractMatrix, α::Number, β::Number) = mul!(C, transpose(A.parent.A), B, α, β)
 
 function mul!(C::StridedVecOrMat, A::ThreadedSparseMatrixCSC, B::Union{StridedVector,AdjOrTransDenseMatrix}, α::Number, β::Number)
     size(A, 2) == size(B, 1) || throw(DimensionMismatch())

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ using Test
     T = ComplexF64
 
     C = sprand(T, N, n, 0.05)
-    @testset "$(Mat)_R" for Mat in [ThreadedSparseMatrixCSC, ThreadedColumnizedSparseMatrix]
+    @testset "$(Mat)_R" for Mat in [ThreadedSparseMatrixCSC]
         Ct = Mat(C)
 
         eye = Matrix(one(T)*I, N, N)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,8 +56,7 @@ using Test
     @testset "$(Mat)_L_sparsevec" for Mat in [ThreadedSparseMatrixCSC]
         Ct = Mat(C)
 
-        out = similar(sx, T, N)
-        LinearAlgebra.mul!(out, Ct, sx)
+        out = Ct*sx
         ref = C*sx
         @test norm(ref-out) == 0
         @test typeof(ref)==typeof(out)
@@ -67,8 +66,7 @@ using Test
     @testset "$(Mat)_L_$(op)_sparsevec" for op in [adjoint,transpose], Mat in [ThreadedSparseMatrixCSC]
         Ct = Mat(C)
 
-        out = similar(sx, T, n)
-        LinearAlgebra.mul!(out, op(Ct), sx)
+        out = op(Ct)*sx
         ref = op(C)*sx
         @test norm(ref-out) == 0
         @test typeof(ref)==typeof(out)
@@ -78,8 +76,7 @@ using Test
     @testset "$(Mat)_L_sparse" for Mat in [ThreadedSparseMatrixCSC]
         Ct = Mat(C)
 
-        out = similar(sx, T, N, 10)
-        LinearAlgebra.mul!(out, Ct, sx)
+        out = Ct*sx
         ref = C*sx
         @test norm(ref-out) == 0
         @test typeof(ref)==typeof(out)
@@ -89,8 +86,7 @@ using Test
     @testset "$(Mat)_L_$(op)_sparse" for op in [adjoint,transpose], Mat in [ThreadedSparseMatrixCSC]
         Ct = Mat(C)
 
-        out = similar(sx, T, n, 10)
-        LinearAlgebra.mul!(out, op(Ct), sx)
+        out = op(Ct)*sx
         ref = op(C)*sx
         @test norm(ref-out) == 0
         @test typeof(ref)==typeof(out)


### PR DESCRIPTION
By making `ThreadedSparseMatrixCSC` a subtype of `AbstractSparseMatrixCSC` we can avoid bad fallbacks to generic matmul functions for the cases where we have not implemented threaded versions.

In addition, many methods such as `nnz`, `findnz` and `hash` now work properly. Printing has also improved.