### PR TITLE
Buffer fix

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ThreadedSparseArrays"
 uuid = "59d54670-b8ac-4d81-ab7a-bb56233e17ab"
 authors = ["Stefanos Carlström <stefanos.carlstrom@gmail.com>"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/ThreadedSparseArrays.jl
+++ b/src/ThreadedSparseArrays.jl
@@ -58,9 +58,11 @@ end
     SparseArrays._checkbuffers(A::ThreadedSparseMatrixCSC) = SparseArrays._checkbuffers(A.A)
 end
 
-Base.copy(A::Adjoint{<:Any,<:ThreadedSparseMatrixCSC}) = ThreadedSparseMatrixCSC(copy(A.parent.A'))
-Base.copy(A::Transpose{<:Any,<:ThreadedSparseMatrixCSC}) = ThreadedSparseMatrixCSC(copy(transpose(A.parent.A)))
-Base.permutedims(A::ThreadedSparseMatrixCSC, (a,b))  = ThreadedSparseMatrixCSC(permutedims(A.A, (a,b)))
+for (T,t) in ((ThreadedSparseMatrixCSC,identity), (Adjoint{<:Any,<:ThreadedSparseMatrixCSC},adjoint), (Transpose{<:Any,<:ThreadedSparseMatrixCSC},transpose))
+    @eval Base.copy(A::$T) = ThreadedSparseMatrixCSC(copy($t($t(A).A)))
+    @eval Base.permutedims(A::$T, (a,b)) = ThreadedSparseMatrixCSC(permutedims($t($t(A).A), (a,b)))
+end
+
 
 
 # sparse * sparse multiplications are not (currently) threaded, but we want to keep the return type

--- a/src/ThreadedSparseArrays.jl
+++ b/src/ThreadedSparseArrays.jl
@@ -53,6 +53,16 @@ for f in [:rowvals, :nonzeros, :getcolptr]
 end
 
 
+@static if v"1.7.0" <= VERSION < v"1.8.0-"
+    SparseArrays._goodbuffers(A::ThreadedSparseMatrixCSC) = SparseArrays._goodbuffers(A.A)
+    SparseArrays._checkbuffers(A::ThreadedSparseMatrixCSC) = SparseArrays._checkbuffers(A.A)
+end
+
+Base.copy(A::Adjoint{<:Any,<:ThreadedSparseMatrixCSC}) = ThreadedSparseMatrixCSC(copy(A.parent.A'))
+Base.copy(A::Transpose{<:Any,<:ThreadedSparseMatrixCSC}) = ThreadedSparseMatrixCSC(copy(transpose(A.parent.A)))
+Base.permutedims(A::ThreadedSparseMatrixCSC, (a,b))  = ThreadedSparseMatrixCSC(permutedims(A.A, (a,b)))
+
+
 # sparse * sparse multiplications are not (currently) threaded, but we want to keep the return type
 for (T1,t1) in ((ThreadedSparseMatrixCSC,identity), (Adjoint{<:Any,<:ThreadedSparseMatrixCSC},adjoint), (Transpose{<:Any,<:ThreadedSparseMatrixCSC},transpose))
     for (T2,t2) in ((ThreadedSparseMatrixCSC,identity), (Adjoint{<:Any,<:ThreadedSparseMatrixCSC},adjoint), (Transpose{<:Any,<:ThreadedSparseMatrixCSC},transpose))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,7 +66,7 @@ rand_scalar(rng,::Type{T}) where T<:Complex = T(rand(rng,2 .^ (1:5)) + im*rand(r
     end
 
 
-    @testset "ReturnType" for op1 in [identity,adjoint,transpose], op2 in [identity,adjoint,transpose]
+    @testset "ReturnType_$(op1)_$(op2)" for op1 in [identity,adjoint,transpose], op2 in [identity,adjoint,transpose]
         rng = StableRNG(1234)
         A = rand_sparse(rng,Complex{Int64},10,10,0.4)
         B = rand_sparse(rng,Complex{Int64},10,10,0.4)
@@ -80,6 +80,17 @@ rand_scalar(rng,::Type{T}) where T<:Complex = T(rand(rng,2 .^ (1:5)) + im*rand(r
         out = op1(A)*op2(ThreadedSparseMatrixCSC(B))
         @test out isa SparseMatrixCSC
         @test out == ref
+    end
+
+    @testset "copy_$op" for op in [identity,adjoint,transpose]
+        rng = StableRNG(1234)
+        A = rand_sparse(rng,Complex{Int64},8,10,0.4)
+        out = copy(op(ThreadedSparseMatrixCSC(A)))
+        @test out isa ThreadedSparseMatrixCSC
+        @test out == op(A)
+        out = permutedims(op(ThreadedSparseMatrixCSC(A)))
+        @test out isa ThreadedSparseMatrixCSC
+        @test out == permutedims(op(A))
     end
 
     N = 1000

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,6 +91,10 @@ rand_scalar(rng,::Type{T}) where T<:Complex = T(rand(rng,2 .^ (1:5)) + im*rand(r
         out = permutedims(op(ThreadedSparseMatrixCSC(A)))
         @test out isa ThreadedSparseMatrixCSC
         @test out == permutedims(op(A))
+
+        out = convert(Matrix,op(ThreadedSparseMatrixCSC(A)))
+        @test out isa Matrix
+        @test out == op(A)
     end
 
     N = 1000


### PR DESCRIPTION
Fix for #9.
Also keep type when copying adjoint or transpose or using permutedims.